### PR TITLE
fix(utils.Cachable): asyncio.Lock fix for Python3.9

### DIFF
--- a/tidal_async/api.py
+++ b/tidal_async/api.py
@@ -184,6 +184,7 @@ class Track(TidalObject, generic.Track):
         #   - [x] rewrite title parsing
         #   - [x] replayGain
         #   - [ ] multiple artists
+        #   - [ ] Picard like artist and view artist separation
         album = self.album
         await album.reload_info()
 


### PR DESCRIPTION
asyncio.Lock doesn't support sync context manager since Python 3.9